### PR TITLE
Ensure that a user for the container has been created

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -8,6 +8,9 @@ on:
     types:
       - opened
 
+permissions:
+  issues: write
+
 jobs:
   add-to-osinfra-project:
     name: Open Source Infrastructure (as Code)

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,6 +2,9 @@ name: Dependabot Approve and Merge
 
 on: pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   dependabot:
     name: Dependabot

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,17 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
-  hooks:
-    - id: check-yaml
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-    - id: check-symlinks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-symlinks
+
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: 3.2.128
+    hooks:
+      - id: checkov
+        files: Dockerfile
+        verbose: true
+        args:
+          - --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM golang:1.22.4
 
+# Ensure that HEALTHCHECK instructions have been added to container images
+# checkov:skip=CKV_DOCKER_2: Kubernetes does not support HEALTHCHECK instructions
+
+RUN useradd -m gke-info
+USER gke-info
+
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA
 ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}


### PR DESCRIPTION
The policy’s primary purpose is to verify that a dedicated user has been explicitly created for running the container. This is essential to avoid running the container with root privileges, which could introduce significant security risks in case of a compromise. Running containers as a non-root user reduces the potential impact of a security breach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub workflows to enhance permissions for issues and pull requests.
  - Added a `checkov` hook for pre-commit checks to improve code quality.

- **New Features**
  - Introduced HEALTHCHECK instructions and user management improvements in Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->